### PR TITLE
[Add] A new Ctest to Metadata

### DIFF
--- a/ctest_metadata.csv
+++ b/ctest_metadata.csv
@@ -124,3 +124,5 @@ https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, 
 https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.zk.timeout-ms,org.apache.hadoop.util.curator.TestZKCuratorManager#testChildren, 10000, GOOD, PASS
 https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.zk.timeout-ms,org.apache.hadoop.util.curator.TestZKCuratorManager#testChildren, 20000, GOOD, PASS
 https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.zk.timeout-ms,org.apache.hadoop.util.curator.TestZKCuratorManager#testChildren, 30000, GOOD, PASS
+https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.security.crypto.cipher.suite,org.apache.hadoop.crypto.TestCryptoOutputStreamClosing#testOutputStreamClosing, AES/CTR/NoPadding, GOOD, PASS,
+https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.security.crypto.cipher.suite,org.apache.hadoop.crypto.TestCryptoOutputStreamClosing#testOutputStreamClosing, AES/CTR/Padding, BAD, FAIL,

--- a/ctest_metadata.csv
+++ b/ctest_metadata.csv
@@ -124,5 +124,5 @@ https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, 
 https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.zk.timeout-ms,org.apache.hadoop.util.curator.TestZKCuratorManager#testChildren, 10000, GOOD, PASS
 https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.zk.timeout-ms,org.apache.hadoop.util.curator.TestZKCuratorManager#testChildren, 20000, GOOD, PASS
 https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.zk.timeout-ms,org.apache.hadoop.util.curator.TestZKCuratorManager#testChildren, 30000, GOOD, PASS
-https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.security.crypto.cipher.suite,org.apache.hadoop.crypto.TestCryptoOutputStreamClosing#testOutputStreamClosing, AES/CTR/NoPadding, GOOD, PASS,
-https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.security.crypto.cipher.suite,org.apache.hadoop.crypto.TestCryptoOutputStreamClosing#testOutputStreamClosing, AES/CTR/Padding, BAD, FAIL,
+https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.security.crypto.cipher.suite,org.apache.hadoop.crypto.TestCryptoOutputStreamClosing#testOutputStreamClosing, AES/CTR/NoPadding, GOOD, PASS
+https://github.com/apache/hadoop.git, a3b9c37a397ad4188041dd80621bdeefc46885f2, hadoop.security.crypto.cipher.suite,org.apache.hadoop.crypto.TestCryptoOutputStreamClosing#testOutputStreamClosing, AES/CTR/Padding, BAD, FAIL


### PR DESCRIPTION
After receiving the evaluation task, I spent about two days reading the paper and source code of Hadoop and IDoCT. Therefore, I'm able to add a Ctest to `ctest_metadata.csv`.

* org.apache.hadoop.crypto.TestCryptoOutputStreamClosing#testOutputStreamClosing
  * hadoop.security.crypto.cipher.suite
    * GOOD: AES/CTR/NoPadding
    * BAD: AES/CTR/Padding

I have to admit that this pull request is just a similar Ctest in the instruction and it's elementary, but I'm glad to see that I know how Ctest works and confident for the future work to find more Ctests or rewrite some tests.

