### PR TITLE
[Add] Four rewritten tests based on hadoop-commen

### DIFF
--- a/hadoop/test_rewrite/org.apache.hadoop.crypto.key.kms.TestLoadBalancingKMSClientProvider.patch
+++ b/hadoop/test_rewrite/org.apache.hadoop.crypto.key.kms.TestLoadBalancingKMSClientProvider.patch
@@ -1,0 +1,23 @@
+diff --git a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/kms/TestLoadBalancingKMSClientProvider.java b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/kms/TestLoadBalancingKMSClientProvider.java
+index 616c66b0748..b50c0f739a2 100644
+--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/kms/TestLoadBalancingKMSClientProvider.java
++++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/kms/TestLoadBalancingKMSClientProvider.java
+@@ -882,8 +882,6 @@ public void testClientRetriesNonIdempotentOpWithSocketTimeoutExceptionFails()
+   public void testTokenServiceCreationWithLegacyFormat() throws Exception {
+     Configuration conf = new Configuration();
+     // Create keyprovider with old token format (ip:port)
+-    conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH,
+-        "kms:/something");
+     String authority = "host1:9600";
+     URI kmsUri = URI.create("kms://http@" + authority + "/kms/foo");
+     KeyProvider kp =
+@@ -892,9 +890,6 @@ public void testTokenServiceCreationWithLegacyFormat() throws Exception {
+     LoadBalancingKMSClientProvider lbkp = (LoadBalancingKMSClientProvider) kp;
+     assertEquals(1, lbkp.getProviders().length);
+     assertEquals(authority, lbkp.getCanonicalServiceName());
+-    for (KMSClientProvider provider : lbkp.getProviders()) {
+-      assertEquals(authority, provider.getCanonicalServiceName());
+-    }
+   }
+ 
+   @Test

--- a/hadoop/test_rewrite/org.apache.hadoop.ipc.TestIdentityProviders.patch
+++ b/hadoop/test_rewrite/org.apache.hadoop.ipc.TestIdentityProviders.patch
@@ -1,0 +1,23 @@
+diff --git a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIdentityProviders.java b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIdentityProviders.java
+index 263841246bf..df1a1115025 100644
+--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIdentityProviders.java
++++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/ipc/TestIdentityProviders.java
+@@ -54,18 +54,12 @@ public int getPriorityLevel() {
+   @Test
+   public void testPluggableIdentityProvider() {
+     Configuration conf = new Configuration();
+-    conf.set(CommonConfigurationKeys.IPC_IDENTITY_PROVIDER_KEY,
+-      "org.apache.hadoop.ipc.UserIdentityProvider");
+-
+     List<IdentityProvider> providers = conf.getInstances(
+       CommonConfigurationKeys.IPC_IDENTITY_PROVIDER_KEY,
+       IdentityProvider.class);
+ 
+     assertTrue(providers.size() == 1);
+ 
+-    IdentityProvider ip = providers.get(0);
+-    assertNotNull(ip);
+-    assertEquals(ip.getClass(), UserIdentityProvider.class);
+   }
+ 
+   @Test

--- a/hadoop/test_rewrite/org.apache.hadoop.net.TestSwitchMapping.patch
+++ b/hadoop/test_rewrite/org.apache.hadoop.net.TestSwitchMapping.patch
@@ -1,0 +1,20 @@
+diff --git a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSwitchMapping.java b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSwitchMapping.java
+index b5de661caca..589b59ac8dd 100644
+--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSwitchMapping.java
++++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/net/TestSwitchMapping.java
+@@ -70,15 +70,9 @@ public void testCachingRelays() throws Throwable {
+   public void testCachingRelaysStringOperations() throws Throwable {
+     Configuration conf = new Configuration();
+     String scriptname = "mappingscript.sh";
+-    conf.set(CommonConfigurationKeys.NET_TOPOLOGY_SCRIPT_FILE_NAME_KEY,
+-             scriptname);
+     ScriptBasedMapping scriptMapping = new ScriptBasedMapping(conf);
+     assertTrue("Did not find " + scriptname + " in " + scriptMapping,
+                scriptMapping.toString().contains(scriptname));
+-    CachedDNSToSwitchMapping mapping =
+-        new CachedDNSToSwitchMapping(scriptMapping);
+-    assertTrue("Did not find " + scriptname + " in " + mapping,
+-               mapping.toString().contains(scriptname));
+   }
+ 
+   /**

--- a/hadoop/test_rewrite/org.apache.hadoop.security.TestLdapGroupsMapping.patch
+++ b/hadoop/test_rewrite/org.apache.hadoop.security.TestLdapGroupsMapping.patch
@@ -1,0 +1,12 @@
+diff --git a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+index aba39971877..705439b5d6d 100644
+--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
++++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/TestLdapGroupsMapping.java
+@@ -317,7 +317,6 @@ public void testConfGetPasswordUsingAlias() throws Exception {
+ 
+     File file = new File(testDir, "test.jks");
+     file.delete();
+-    conf.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, ourUrl);
+ 
+     // Set alias
+     String bindpassAlias = "bindpassAlias";


### PR DESCRIPTION
Based on the information from [Ctest](https://tianyin.github.io/pub/ctest.pdf) and [examples](https://github.com/xlab-uiuc/openctest/tree/main/data/test_rewrite), I rewrite 4 tests which are all hardcoded tests in the hadoop-common project and generate 4 git patch files. After removing the `set` call, the parameter to be tested comes from system configuration, which means rewritten ctest can then test it.

I notice that there is no tsv file like [test_rewrite.tsv](https://github.com/xlab-uiuc/openctest/blob/main/data/test_rewrite/test_rewrite.tsv) in this repo. If ok, I'd like to make another PR to fulfill this work. :)