### PR TITLE
[Add] add a tsv file and a patch file

### DIFF
--- a/hadoop/test_rewrite/org.apache.hadoop.crypto.key.TestKeyProvider.patch
+++ b/hadoop/test_rewrite/org.apache.hadoop.crypto.key.TestKeyProvider.patch
@@ -1,0 +1,21 @@
+diff --git a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
+index cb6a1fb31e6..e1136c3c0b6 100644
+--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
++++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/crypto/key/TestKeyProvider.java
+@@ -125,13 +125,12 @@ public void testMetadata() throws Exception {
+   @Test
+   public void testOptions() throws Exception {
+     Configuration conf = new Configuration();
+-    conf.set(KeyProvider.DEFAULT_CIPHER_NAME, "myCipher");
+-    conf.setInt(KeyProvider.DEFAULT_BITLENGTH_NAME, 512);
+     Map<String, String> attributes = new HashMap<String, String>();
+     attributes.put("a", "A");
+     KeyProvider.Options options = KeyProvider.options(conf);
+-    assertEquals("myCipher", options.getCipher());
+-    assertEquals(512, options.getBitLength());
++    assertEquals(conf.get(KeyProvider.DEFAULT_CIPHER_NAME), options.getCipher());
++    assertEquals(conf.getInt(KeyProvider.DEFAULT_BITLENGTH_NAME, 0),
++        options.getBitLength());
+     options.setCipher("yourCipher");
+     options.setDescription("description");
+     options.setAttributes(attributes);

--- a/hadoop/test_rewrite/test_rewrite.tsv
+++ b/hadoop/test_rewrite/test_rewrite.tsv
@@ -1,0 +1,6 @@
+project	param	setter	
+hadoop-common	hadoop.security.key.provider.path	org.apache.hadoop.crypto.key.TestKeyProviderFactory#testFactory	
+hadoop-common	hadoop.security.key.provider.path	org.apache.hadoop.crypto.key.kms.TestLoadBalancingKMSClientProvider#testClientRetriesNonIdempotentOpWithSocketTimeoutExceptionFails	
+hadoop-common	identity-provider.impl	org.apache.hadoop.ipc.TestIdentityProviders#testPluggableIdentityProvider	
+hadoop-common	net.topology.script.file.name	org.apache.hadoop.net.TestSwitchMapping#testCachingRelaysStringOperations	
+hadoop-common	hadoop.security.credential.provider.path	org.apache.hadoop.security.TestLdapGroupsMapping#testConfGetPasswordUsingAlias	


### PR DESCRIPTION
Since my PR is merged, I'm able to add a tsv file to the test_rewrite directory to record the rewritten test information.

Besides, during my time in finding and rewriting tests, I found most tests, like the test I rewrite this time, are hardcoded configuration, then an assertion will test the equality. The type of this Ctest is easy to rewrite, we just need to use`conf.get` to get the actual value.

However, I found many other tests that didn't set a param from `CommonConfigurationKeysPublic.java`, but from its own file. For example,
`conf.set(AvroReflectSerialization.AVRO_REFLECT_PACKAGES, before.getClass().getPackage().getName());`,
in this code, `AvroReflectSerialization.AVRO_REFLECT_PACKAGES` actually comes from another `final string "avro.reflect.pkgs"`. It maybe not related to the system configuration param, but I do think if we can set this param through our python script, our test work can become more complete. And I'm trying to modify script to do this injection work.

