### PR TITLE
rewrite the regex for test name

### DIFF
--- a/format_checker/common_checks.py
+++ b/format_checker/common_checks.py
@@ -14,7 +14,7 @@ from utils import (
 common_data = {
     "REPO": re.compile(r"^https://github.com/apache/hadoop.git$"),
     "SHA": re.compile(r"^a3b9c37a397ad4188041dd80621bdeefc46885f2$"),
-    "TEST_NAME": re.compile(r"^.*#test.*$"),
+    "TEST_NAME": re.compile(r"^.*#.*$"),
 }
 
 


### PR DESCRIPTION
### Issue

Some tests name don't start with "test". That will cause incorrect result for correct csv file.

### Example
Tests under 'org.apache.hadoop.fs.shell.TestLs':
```
org.apache.hadoop.fs.shell.TestLs#processPathDirOrderAtimeReverse
org.apache.hadoop.fs.shell.TestLs#processPathDirOrderLengthLarge
org.apache.hadoop.fs.shell.TestLs#processPathFiles
...
org.apache.hadoop.fs.shell.TestLs#processPathDirectoryAtime
```

### Changes
Rewrite the regex for test name in `common_checks.py` file.